### PR TITLE
fix: VST3 plugin DAW recognition, crash-on-close, and dark theme color cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,10 +96,12 @@ if(NOMAD_BUILD_PLUGIN)
         FORMATS VST3 AU Standalone
         PRODUCT_NAME "Nomad2026"
         COMPANY_NAME "Nomad2026"
-        IS_MIDI_EFFECT TRUE
+        IS_SYNTH TRUE
+        IS_MIDI_EFFECT FALSE
         NEEDS_MIDI_INPUT TRUE
         NEEDS_MIDI_OUTPUT TRUE
         EDITOR_WANTS_KEYBOARD_FOCUS TRUE
+        VST3_CATEGORIES "Instrument" "Tools"
         VERSION "0.5.5"
     )
 

--- a/source/MainComponent.cpp
+++ b/source/MainComponent.cpp
@@ -128,8 +128,9 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
   // Wire connection manager status updates to UI
   connectionManager.setStatusCallback(
       [this](const ConnectionManager::Status &status) {
+        juce::Component::SafePointer<MainComponent> safeThis(this);
         juce::MessageManager::callAsync(
-            [this, status]() { onConnectionStatusChanged(status); });
+            [safeThis, status]() { if (safeThis) safeThis->onConnectionStatusChanged(status); });
       });
 
   connectionManager.setVoiceCountCallback([this](const int voiceCounts[4]) {
@@ -138,10 +139,12 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
     int c0 = voiceCounts[0], c1 = voiceCounts[1], c2 = voiceCounts[2], c3 = voiceCounts[3];
     DBG("[DSP] VoiceCount: " + juce::String(c0) + " " + juce::String(c1) + " "
         + juce::String(c2) + " " + juce::String(c3) + " total=" + juce::String(total));
+    juce::Component::SafePointer<MainComponent> safeThis(this);
     juce::MessageManager::callAsync(
-        [this, total, c0, c1, c2, c3]() {
-          mainLayout->getStatusBar().setVoiceCount(total);
-          mainLayout->getHeaderBar().setSynthDspLoad(c0, c1, c2, c3);
+        [safeThis, total, c0, c1, c2, c3]() {
+          if (!safeThis) return;
+          safeThis->mainLayout->getStatusBar().setVoiceCount(total);
+          safeThis->mainLayout->getHeaderBar().setSynthDspLoad(c0, c1, c2, c3);
         });
   });
 
@@ -215,9 +218,11 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
 
   // Wire patch list updates to patch browser panel
   connectionManager.setPatchListCallback([this](const std::vector<std::string>& names) {
-    juce::MessageManager::callAsync([this, names]() {
-      mainLayout->getPatchBrowser().setPatchList(names);
-      mainLayout->getPatchBrowser().setLoadingState(false);
+    juce::Component::SafePointer<MainComponent> safeThis(this);
+    juce::MessageManager::callAsync([safeThis, names]() {
+      if (!safeThis) return;
+      safeThis->mainLayout->getPatchBrowser().setPatchList(names);
+      safeThis->mainLayout->getPatchBrowser().setLoadingState(false);
     });
   });
 
@@ -300,54 +305,56 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
         PatchParser parser(moduleDescs);
         auto patch = parser.parse(sections);
 
-        juce::MessageManager::callAsync([this, p = std::move(patch), targetSlot]() mutable {
+        juce::Component::SafePointer<MainComponent> safeThis(this);
+        juce::MessageManager::callAsync([safeThis, p = std::move(patch), targetSlot]() mutable {
+          if (!safeThis) return;
           if (targetSlot < 0 || targetSlot >= numSlots)
             return;
 
           // Store patch in the correct slot
-          slotSynchronizers[targetSlot].reset();
+          safeThis->slotSynchronizers[targetSlot].reset();
 
           // If replacing the active slot, clear UI refs BEFORE destroying old patch
-          if (targetSlot == activeSlot) {
-            mainLayout->getInspector().clearModule();
+          if (targetSlot == safeThis->activeSlot) {
+            safeThis->mainLayout->getInspector().clearModule();
           }
 
-          slotPatches[targetSlot] = std::move(p);
-          if (slotPatches[targetSlot]) {
-            if (connectionManager.isConnected()) {
-              slotSynchronizers[targetSlot] = std::make_unique<PatchSynchronizer>(
-                  *slotPatches[targetSlot], connectionManager);
+          safeThis->slotPatches[targetSlot] = std::move(p);
+          if (safeThis->slotPatches[targetSlot]) {
+            if (safeThis->connectionManager.isConnected()) {
+              safeThis->slotSynchronizers[targetSlot] = std::make_unique<PatchSynchronizer>(
+                  *safeThis->slotPatches[targetSlot], safeThis->connectionManager);
             }
 
-            slotUndoManagers[targetSlot].clearUndoHistory();
-            rebuildUndoContext(targetSlot);
-            clearSnapshots(targetSlot);
+            safeThis->slotUndoManagers[targetSlot].clearUndoHistory();
+            safeThis->rebuildUndoContext(targetSlot);
+            safeThis->clearSnapshots(targetSlot);
 
             // If this is the currently viewed slot, update the UI
-            if (targetSlot == activeSlot) {
-              mainLayout->getCanvas().setPatch(currentPatch().get(), &moduleDescs, &themeData);
-              mainLayout->getHeaderBar().setPatch(currentPatch().get());
-              mainLayout->getInspector().setPatch(currentPatch().get());
-              updateDspLoadDisplay();
-              mainLayout->getStatusBar().setConnectionStatus(
-                  "Connected - " + currentPatch()->getName(), true);
+            if (targetSlot == safeThis->activeSlot) {
+              safeThis->mainLayout->getCanvas().setPatch(safeThis->currentPatch().get(), &safeThis->moduleDescs, &safeThis->themeData);
+              safeThis->mainLayout->getHeaderBar().setPatch(safeThis->currentPatch().get());
+              safeThis->mainLayout->getInspector().setPatch(safeThis->currentPatch().get());
+              safeThis->updateDspLoadDisplay();
+              safeThis->mainLayout->getStatusBar().setConnectionStatus(
+                  "Connected - " + safeThis->currentPatch()->getName(), true);
 
-              int ls = connectionManager.getLastLoadedSection();
-              int lp = connectionManager.getLastLoadedPosition();
+              int ls = safeThis->connectionManager.getLastLoadedSection();
+              int lp = safeThis->connectionManager.getLastLoadedPosition();
               if (ls >= 0 && lp >= 0)
-                  mainLayout->getPatchBrowser().setLoadedPatch(ls, lp);
+                  safeThis->mainLayout->getPatchBrowser().setLoadedPatch(ls, lp);
             }
 
             // Update slot bar with patch name
-            mainLayout->getSlotBar().setSlotName(targetSlot, slotPatches[targetSlot]->getName());
+            safeThis->mainLayout->getSlotBar().setSlotName(targetSlot, safeThis->slotPatches[targetSlot]->getName());
 
             const char* slotLetters[] = {"A", "B", "C", "D"};
             std::cout << "[SYNC] Patch loaded into slot " << slotLetters[targetSlot]
-                      << ": " << slotPatches[targetSlot]->getName().toStdString() << std::endl;
+                      << ": " << safeThis->slotPatches[targetSlot]->getName().toStdString() << std::endl;
           }
 
-          if (pendingBrowserLoadSlot == targetSlot)
-            pendingBrowserLoadSlot = -1;
+          if (safeThis->pendingBrowserLoadSlot == targetSlot)
+            safeThis->pendingBrowserLoadSlot = -1;
         });
       });
 
@@ -585,8 +592,10 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
           std::array<int,128> l, me;
           std::copy(lights,  lights  + 128, l.begin());
           std::copy(meters, meters + 128, me.begin());
-          juce::MessageManager::callAsync([this, l, me]() mutable {
-              mainLayout->getCanvas().setLightMeterData(l.data(), me.data());
+          juce::Component::SafePointer<MainComponent> safeThis(this);
+          juce::MessageManager::callAsync([safeThis, l, me]() mutable {
+              if (!safeThis) return;
+              safeThis->mainLayout->getCanvas().setLightMeterData(l.data(), me.data());
           });
       });
 
@@ -620,25 +629,27 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
   connectionManager.setParameterChangeCallback([this](int section, int moduleId,
                                                       int parameterId,
                                                       int value) {
-    juce::MessageManager::callAsync([this, section, moduleId, parameterId,
+    juce::Component::SafePointer<MainComponent> safeThis(this);
+    juce::MessageManager::callAsync([safeThis, section, moduleId, parameterId,
                                      value]() {
-      if (currentPatch() == nullptr)
+      if (!safeThis) return;
+      if (safeThis->currentPatch() == nullptr)
         return;
 
       // Morph section (section=2, module=1, parameter=0-3)
       if (section == 2 && moduleId == 1 && parameterId >= 0 &&
           parameterId < 4) {
-        currentPatch()->morphValues[static_cast<size_t>(parameterId)] = value;
-        mainLayout->getHeaderBar().repaint();
+        safeThis->currentPatch()->morphValues[static_cast<size_t>(parameterId)] = value;
+        safeThis->mainLayout->getHeaderBar().repaint();
         return;
       }
 
       // Skip if the user is currently dragging this exact parameter (avoid
       // fighting the user)
-      if (mainLayout->getCanvas().isDragging(section, moduleId, parameterId))
+      if (safeThis->mainLayout->getCanvas().isDragging(section, moduleId, parameterId))
         return;
 
-      auto &container = currentPatch()->getContainer(section);
+      auto &container = safeThis->currentPatch()->getContainer(section);
       auto *module = container.getModuleByIndex(moduleId);
       if (module == nullptr)
         return;
@@ -651,7 +662,7 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
       // repaints)
       if (param->getValue() != value) {
         param->setValue(value);
-        mainLayout->getCanvas().repaintCanvas();
+        safeThis->mainLayout->getCanvas().repaintCanvas();
       }
     });
   });
@@ -677,31 +688,56 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
 
   // Wire synth slot changes (user presses slot button on hardware)
   connectionManager.setSlotChangedCallback([this](int slot) {
-    juce::MessageManager::callAsync([this, slot]() {
-      if (pendingBrowserLoadSlot >= 0 && slot != pendingBrowserLoadSlot) {
+    juce::Component::SafePointer<MainComponent> safeThis(this);
+    juce::MessageManager::callAsync([safeThis, slot]() {
+      if (!safeThis) return;
+      if (safeThis->pendingBrowserLoadSlot >= 0 && slot != safeThis->pendingBrowserLoadSlot) {
         std::cout << "[SLOT] Ignoring stale slot change " << slot
-                  << " during browser load to slot " << pendingBrowserLoadSlot << std::endl;
+                  << " during browser load to slot " << safeThis->pendingBrowserLoadSlot << std::endl;
         return;
       }
-      mainLayout->getSlotBar().setCurrentTab(slot);
-      switchToSlot(slot, /*notifySynth=*/false);
+      safeThis->mainLayout->getSlotBar().setCurrentTab(slot);
+      safeThis->switchToSlot(slot, /*notifySynth=*/false);
     });
   });
 
   setSize(1280, 800);
 
   // Auto-connect after UI is set up (with delay to let ALSA enumerate devices)
-  juce::Timer::callAfterDelay(500, [this]() { attemptAutoConnect(); });
+  {
+    juce::Component::SafePointer<MainComponent> safeThis(this);
+    juce::Timer::callAfterDelay(500, [safeThis]() { if (safeThis) safeThis->attemptAutoConnect(); });
 
-  // Show beta warning dialog (after UI is ready)
-  juce::Timer::callAfterDelay(800, [this]() { showBetaWarning(); });
+    // Show beta warning dialog (after UI is ready)
+    juce::Timer::callAfterDelay(800, [safeThis]() { if (safeThis) safeThis->showBetaWarning(); });
+  }
 }
 
 MainComponent::~MainComponent() {
+  // Stop interpolation timer before anything else
+  if (interpolationTimer)
+    interpolationTimer->stopTimer();
+  interpolationTimer.reset();
+
+  // Disconnect MIDI and clear all async callbacks to prevent post-destruction
+  // dispatches (fixes crash-on-close in plugin builds)
+  connectionManager.disconnect();
+  connectionManager.setStatusCallback(nullptr);
+  connectionManager.setVoiceCountCallback(nullptr);
+  connectionManager.setPatchDataCallback(nullptr);
+  connectionManager.setParameterChangeCallback(nullptr);
+  connectionManager.setSynthErrorCallback(nullptr);
+  connectionManager.setSlotChangedCallback(nullptr);
+  connectionManager.setUploadCompleteCallback(nullptr);
+  connectionManager.setLightMeterCallback(nullptr);
+  connectionManager.setPatchListCallback(nullptr);
+
+  // Tear down UI before members are destroyed
 #if JUCE_MAC
   juce::MenuBarModel::setMacMainMenu(nullptr);
 #endif
   menuBar.reset();
+  mainLayout.reset();
 }
 
 void MainComponent::resized() {
@@ -1359,7 +1395,8 @@ void MainComponent::attemptAutoConnect() {
       autoConnectRetries--;
       DBG("No MIDI devices found yet, retrying in 500ms (" +
           juce::String(autoConnectRetries) + " left)");
-      juce::Timer::callAfterDelay(500, [this]() { attemptAutoConnect(); });
+      juce::Component::SafePointer<MainComponent> safeThis(this);
+      juce::Timer::callAfterDelay(500, [safeThis]() { if (safeThis) safeThis->attemptAutoConnect(); });
     } else {
       DBG("Saved MIDI ports not found (id=" + savedInputId + "/" +
           savedOutputId + " name=" + savedInputName + "/" + savedOutputName +

--- a/source/midi/ConnectionManager.cpp
+++ b/source/midi/ConnectionManager.cpp
@@ -14,6 +14,8 @@ ConnectionManager::ConnectionManager()
 
 ConnectionManager::~ConnectionManager()
 {
+    *alive = false;   // Cancel any pending Timer::callAfterDelay lambdas
+    protocol.stopTimer();
     protocol.removeListener(this);
     disconnect();
 }
@@ -204,7 +206,9 @@ void ConnectionManager::loadPatchFromBank(int section, int position, int targetS
 
     // Prefer the synth's NewPatchInSlot notification. This fallback covers
     // devices/firmware paths that ACK the load but do not emit sc=0x38.
-    juce::Timer::callAfterDelay(1200, [this, slot, loadGeneration]() {
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(1200, [this, slot, loadGeneration, aliveFlag]() {
+        if (!*aliveFlag) return;
         if (!isConnected())
             return;
 
@@ -441,7 +445,9 @@ void ConnectionManager::drainAckedQueue()
 
     // 3-second timeout: if no ACK arrives, unblock the queue.
     // The generation check ensures only the timeout for the *current* message fires.
-    juce::Timer::callAfterDelay(ackedTimeoutMs, [this, generation]() {
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(ackedTimeoutMs, [this, generation, aliveFlag]() {
+        if (!*aliveFlag) return;
         if (ackedQueueWaiting && ackedQueueGeneration == generation)
         {
             std::cout << "[QUEUE] ACK timeout (gen=" << generation << ") — unblocking queue ("
@@ -525,8 +531,10 @@ void ConnectionManager::requestPatchList()
 
     // Start timeout
     int generation = patchListGeneration;
-    juce::Timer::callAfterDelay(patchListTimeoutMs, [this, generation]()
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(patchListTimeoutMs, [this, generation, aliveFlag]()
     {
+        if (!*aliveFlag) return;
         if (generation == patchListGeneration && fetchingPatchList)
         {
             std::cout << "[PATCHLIST] TIMEOUT - delivering partial results" << std::endl;
@@ -639,8 +647,10 @@ void ConnectionManager::startPatchTimeout()
     int generation = patchTimeoutGeneration;
 
     // Hard timeout: absolute max wait for entire patch
-    juce::Timer::callAfterDelay(patchTimeoutMs, [this, generation]()
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(patchTimeoutMs, [this, generation, aliveFlag]()
     {
+        if (!*aliveFlag) return;
         if (generation == patchTimeoutGeneration && collectingSections && sectionsReceived < totalSections)
         {
             DBG("Patch hard timeout: received " + juce::String(sectionsReceived) + "/" + juce::String(totalSections)
@@ -655,8 +665,10 @@ void ConnectionManager::startSectionStaleTimeout()
     int generation = patchTimeoutGeneration;
     int currentCount = sectionsReceived;
 
-    juce::Timer::callAfterDelay(sectionStaleMs, [this, generation, currentCount]()
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(sectionStaleMs, [this, generation, currentCount, aliveFlag]()
     {
+        if (!*aliveFlag) return;
         // Fire if no new sections arrived since this timer was started
         if (generation == patchTimeoutGeneration && collectingSections
             && sectionsReceived == currentCount && sectionsReceived > 0
@@ -945,8 +957,10 @@ void ConnectionManager::setStatus(State state, const juce::String& message)
 void ConnectionManager::startHandshakeTimeout()
 {
     // Use a Timer via callAfterDelay for the 3-second handshake timeout
-    juce::Timer::callAfterDelay(NmProtocol::timeoutMs, [this]()
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(NmProtocol::timeoutMs, [this, aliveFlag]()
     {
+        if (!*aliveFlag) return;
         if (status.state == State::Connecting)
         {
             DBG("ConnectionManager: handshake timeout");
@@ -965,8 +979,10 @@ void ConnectionManager::startSlotDetectionFallback()
 {
     int generation = slotDetectGeneration;
 
-    juce::Timer::callAfterDelay(3000, [this, generation]()
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(3000, [this, generation, aliveFlag]()
     {
+        if (!*aliveFlag) return;
         // Only fire if no SlotActivated/NewPatchInSlot arrived and we're still connected
         if (generation == slotDetectGeneration && !slotDetected && isConnected()
             && !waitingForPatchAck && !collectingSections)
@@ -994,7 +1010,9 @@ void ConnectionManager::copyPatchInBank(int srcSection, int srcPosition, int dst
 
         storeLoadedSlotToBank(tempSlot, dstSection, dstPosition, [this]() {
             std::cout << "[COPY] Copy complete!" << std::endl;
-            juce::Timer::callAfterDelay(300, [this]() {
+            auto aliveFlag = alive;
+            juce::Timer::callAfterDelay(300, [this, aliveFlag]() {
+                if (!*aliveFlag) return;
                 if (isConnected())
                     requestPatchList();
             });
@@ -1028,7 +1046,9 @@ void ConnectionManager::movePatchInBank(int srcSection, int srcPosition, int dst
             std::cout << "[MOVE] Move complete; delete queued for source bank ("
                       << srcSection << "," << srcPosition << ")" << std::endl;
 
-            juce::Timer::callAfterDelay(500, [this]() {
+            auto aliveFlag = alive;
+            juce::Timer::callAfterDelay(500, [this, aliveFlag]() {
+                if (!*aliveFlag) return;
                 if (isConnected())
                     requestPatchList();
             });
@@ -1049,7 +1069,9 @@ void ConnectionManager::deletePatchInBank(int section, int position)
     DeletePatchMessage msg(section, position);
     sendAckedSysEx(msg.toSysEx());
 
-    juce::Timer::callAfterDelay(500, [this]() {
+    auto aliveFlag = alive;
+    juce::Timer::callAfterDelay(500, [this, aliveFlag]() {
+        if (!*aliveFlag) return;
         if (isConnected())
             requestPatchList();
     });

--- a/source/midi/ConnectionManager.h
+++ b/source/midi/ConnectionManager.h
@@ -2,6 +2,7 @@
 
 #include "NmProtocol.h"
 #include "MidiDeviceManager.h"
+#include <atomic>
 #include <functional>
 
 class Patch;
@@ -133,6 +134,7 @@ private:
     void finalizePatch();
     void storeLoadedSlotToBank(int slot, int section, int position, std::function<void()> afterStoreQueued = {});
 
+    std::shared_ptr<std::atomic<bool>> alive { std::make_shared<std::atomic<bool>>(true) };
     NmProtocol protocol;
     std::unique_ptr<MidiDeviceManager> midiDevice;
     Status status;

--- a/source/midi/MidiDeviceManager.cpp
+++ b/source/midi/MidiDeviceManager.cpp
@@ -12,6 +12,7 @@ MidiDeviceManager::MidiDeviceManager(NmProtocol& proto)
 
 MidiDeviceManager::~MidiDeviceManager()
 {
+    *alive = false;   // Cancel any pending callAsync lambdas
     disconnect();
 }
 
@@ -96,8 +97,10 @@ void MidiDeviceManager::handleIncomingMidiMessage(juce::MidiInput*, const juce::
 
     // Forward to protocol on the message thread
     auto sysexCopy = std::make_shared<std::vector<uint8_t>>(data, data + size);
-    juce::MessageManager::callAsync([this, sysexCopy]()
+    auto aliveFlag = alive;  // prevent use-after-free on plugin close
+    juce::MessageManager::callAsync([this, sysexCopy, aliveFlag]()
     {
+        if (!*aliveFlag) return;
 #if JUCE_DEBUG
         // Suppress logging for high-frequency NMInfo messages (Lights=0x39, Meters=0x3a, VoiceCount=0x05)
         bool suppress = false;

--- a/source/midi/MidiDeviceManager.h
+++ b/source/midi/MidiDeviceManager.h
@@ -2,6 +2,7 @@
 
 #include <juce_audio_devices/juce_audio_devices.h>
 #include "NmProtocol.h"
+#include <atomic>
 #include <memory>
 
 class MidiDeviceManager : private juce::MidiInputCallback
@@ -32,6 +33,7 @@ private:
     NmProtocol& protocol;
     std::unique_ptr<juce::MidiInput> midiInput;
     std::unique_ptr<juce::MidiOutput> midiOutput;
+    std::shared_ptr<std::atomic<bool>> alive { std::make_shared<std::atomic<bool>>(true) };
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(MidiDeviceManager)
 };

--- a/source/plugin/PluginEditor.cpp
+++ b/source/plugin/PluginEditor.cpp
@@ -12,6 +12,13 @@ NomadPluginEditor::NomadPluginEditor(NomadPluginProcessor& processor)
     setResizable(true, true);
 }
 
+NomadPluginEditor::~NomadPluginEditor()
+{
+    // Destroy MainComponent before the editor's Component base class destructor
+    // runs — prevents dangling child-component and async callback crashes.
+    mainComponent.reset();
+}
+
 void NomadPluginEditor::resized()
 {
     mainComponent->setBounds(getLocalBounds());

--- a/source/plugin/PluginEditor.h
+++ b/source/plugin/PluginEditor.h
@@ -8,7 +8,7 @@ class NomadPluginEditor : public juce::AudioProcessorEditor
 {
 public:
     explicit NomadPluginEditor(NomadPluginProcessor& processor);
-    ~NomadPluginEditor() override = default;
+    ~NomadPluginEditor() override;
 
     void resized() override;
 

--- a/source/plugin/PluginProcessor.cpp
+++ b/source/plugin/PluginProcessor.cpp
@@ -2,7 +2,8 @@
 #include "PluginEditor.h"
 
 NomadPluginProcessor::NomadPluginProcessor()
-    : AudioProcessor(BusesProperties())  // No audio buses — MIDI effect only
+    : AudioProcessor(BusesProperties()
+                         .withOutput("Output", juce::AudioChannelSet::stereo(), true))  // Stereo out so DAWs see it as an instrument
 {
     juce::PropertiesFile::Options options;
     options.applicationName = "Nomad2026";

--- a/source/plugin/PluginProcessor.h
+++ b/source/plugin/PluginProcessor.h
@@ -19,7 +19,7 @@ public:
 
     bool acceptsMidi() const override { return true; }
     bool producesMidi() const override { return true; }
-    bool isMidiEffect() const override { return true; }
+    bool isMidiEffect() const override { return false; }
     double getTailLengthSeconds() const override { return 0.0; }
 
     int getNumPrograms() override { return 1; }

--- a/source/ui/ColorScheme.cpp
+++ b/source/ui/ColorScheme.cpp
@@ -73,6 +73,19 @@ static ColorScheme makeClassicTheme()
     // Snap / selection
     s.snapHighlight       = juce::Colour(0xffE5DE45);
     s.selectionRect       = juce::Colours::yellow;
+    s.selectionFill       = juce::Colour(0x33ffffff);
+    // Connector lines
+    s.connectorLine       = juce::Colour(0xff1a1a1a);
+    // Increment buttons
+    s.incrementBg         = juce::Colour(0xff3a3a3a);
+    s.incrementBorder     = juce::Colour(0xff555555);
+    s.incrementFg         = juce::Colour(0xffcccccc);
+    // Mute
+    s.muteActive          = juce::Colour(0xffcc4444);
+    // Vocoder
+    s.vocoderRouting      = juce::Colour(0xff00cc44);
+    // Filter bracket
+    s.bracketRouting      = juce::Colour(0xff888888);
     // SlotBar
     s.slotIconActive      = juce::Colour(0xffcc3333);
     s.slotIconInactive    = juce::Colour(0xff555577);
@@ -152,6 +165,19 @@ static ColorScheme makeDarkTheme()
     // Snap / selection
     s.snapHighlight       = juce::Colour(0xffE5DE45);
     s.selectionRect       = juce::Colour(0xff4444ff);
+    s.selectionFill       = juce::Colour(0x22ffffff);
+    // Connector lines
+    s.connectorLine       = juce::Colour(0xff2a2a2a);
+    // Increment buttons
+    s.incrementBg         = juce::Colour(0xff2a2a2a);
+    s.incrementBorder     = juce::Colour(0xff55585C);
+    s.incrementFg         = juce::Colour(0xffcccccc);
+    // Mute
+    s.muteActive          = juce::Colour(0xffcc4444);
+    // Vocoder
+    s.vocoderRouting      = juce::Colour(0xff2DDCA3);
+    // Filter bracket
+    s.bracketRouting      = juce::Colour(0xff888888);
     // SlotBar
     s.slotIconActive      = juce::Colour(0xffcc3333);
     s.slotIconInactive    = juce::Colour(0xff555577);

--- a/source/ui/ColorScheme.h
+++ b/source/ui/ColorScheme.h
@@ -84,6 +84,24 @@ struct ColorScheme
 
     // Rubber-band selection rect
     juce::Colour selectionRect;
+    juce::Colour selectionFill;
+
+    // Connector/knob linking lines
+    juce::Colour connectorLine;
+
+    // Increment buttons (▲▼ spinners)
+    juce::Colour incrementBg;
+    juce::Colour incrementBorder;
+    juce::Colour incrementFg;
+
+    // Mute button active state
+    juce::Colour muteActive;
+
+    // Vocoder routing display
+    juce::Colour vocoderRouting;
+
+    // Filter bracket routing lines
+    juce::Colour bracketRouting;
 
     // SlotBar synth icon
     juce::Colour slotIconActive;

--- a/source/ui/PatchCanvasComponent.cpp
+++ b/source/ui/PatchCanvasComponent.cpp
@@ -523,7 +523,7 @@ void PatchCanvas::paint(juce::Graphics& g)
     if (showRubberBand)
     {
         auto rb = rubberBandRect.toFloat();
-        g.setColour(juce::Colour(0x33ffffff));
+        g.setColour(activeScheme_.selectionFill);
         g.fillRect(rb);
         g.setColour(activeScheme_.snapHighlight.withAlpha(0.8f));
         g.drawRect(rb, 1.5f);
@@ -902,7 +902,7 @@ void PatchCanvas::paintConnectors(juce::Graphics& g, const Module& m, juce::Rect
     if (m.getDescriptor()->index == 58) return;
 
     const int yTolerance = 12;
-    g.setColour(juce::Colour(0xff1a1a1a));
+    g.setColour(activeScheme_.connectorLine);
     for (auto& tc : theme.connectors)
     {
         if (tc.cssClass == "cSLAVE") continue;
@@ -1890,12 +1890,12 @@ void PatchCanvas::paintButtons(juce::Graphics& g, const Module& m, juce::Rectang
         // --- Increment buttons: draw arrow pairs ---
         if (tb.isIncrement)
         {
-            g.setColour(juce::Colour(0xff3a3a3a));
+            g.setColour(activeScheme_.incrementBg);
             g.fillRect(bx, by, bw, bh);
-            g.setColour(juce::Colour(0xff555555));
+            g.setColour(activeScheme_.incrementBorder);
             g.drawRect(bx, by, bw, bh, 1.0f);
 
-            g.setColour(juce::Colour(0xffcccccc));
+            g.setColour(activeScheme_.incrementFg);
             float cx = bx + bw * 0.5f;
             float cy = by + bh * 0.5f;
 
@@ -1948,7 +1948,7 @@ void PatchCanvas::paintButtons(juce::Graphics& g, const Module& m, juce::Rectang
                                static_cast<int>(bx), static_cast<int>(by + arrowH),
                                static_cast<int>(bw), static_cast<int>(valH),
                                juce::Justification::centred, false);
-                    g.setColour(juce::Colour(0xffcccccc));
+                    g.setColour(activeScheme_.incrementFg);
                 }
 
                 // Down arrow (bottom third)
@@ -2088,7 +2088,7 @@ void PatchCanvas::paintButtons(juce::Graphics& g, const Module& m, juce::Rectang
             float sx = bx + (bw - sq) * 0.5f;
             float sy = by + (bh - sq) * 0.5f;
 
-            juce::Colour muteBase = isOn ? juce::Colour(0xffcc4444) : moduleBg.darker(0.2f);
+            juce::Colour muteBase = isOn ? activeScheme_.muteActive : moduleBg.darker(0.2f);
             juce::Colour muteText = isOn ? juce::Colours::white : activeScheme_.buttonText;
             drawBevelSegment(sx, sy, sq, sq, isOn, muteBase, labelText, muteText, iconRef);
 
@@ -3706,7 +3706,7 @@ void PatchCanvas::paintCustomDisplays(juce::Graphics& g, const Module& m, juce::
             float top     = dy + 1.0f;
             float bot     = dy + dh - 1.0f;
 
-            g.setColour(juce::Colour(0xff00cc44));  // green routing lines (matches original)
+            g.setColour(activeScheme_.vocoderRouting);  // green routing lines (matches original)
             for (int i = 0; i < kBands; ++i)
             {
                 if (cd.bandIds[i].isEmpty()) continue;
@@ -3855,7 +3855,7 @@ void PatchCanvas::paintCustomDisplays(juce::Graphics& g, const Module& m, juce::
             float barX   = outX - 28.0f;  // bar well to the left of the labels (~x=209)
             float lineEnd = outX - 18.0f; // lines stop just before the label text (~x=219)
 
-            g.setColour(juce::Colour(0xff888888)); // grey
+            g.setColour(activeScheme_.bracketRouting); // grey
 
             // Horizontal line from in connector to bar, at BP level (centre of bracket)
             g.drawLine(inX + 7.0f, bpY, barX, bpY, 1.0f);


### PR DESCRIPTION
## Summary

Three related fixes to improve VST3 plugin stability and UI theming:

### 1. VST3 Plugin Config for DAW Recognition
- Set `IS_SYNTH TRUE` and `IS_MIDI_EFFECT FALSE` for proper instrument categorization
- Added stereo output bus to PluginProcessor for audio routing
- Added `VST3_CATEGORIES` for DAW scanner compatibility (tested with Cubase)
- Explicit PluginEditor destructor to ensure MainComponent cleanup order

### 2. Crash-on-Close Fix (VST3)
- Added `shared_ptr<atomic<bool>> alive` flags to MidiDeviceManager and ConnectionManager to guard all `callAsync`/`callAfterDelay` lambdas against use-after-free
- Added `SafePointer<MainComponent>` guards on all `callAsync` lambdas in MainComponent
- Properly stop timers and disconnect callbacks in destructors
- Prevents dangling this-pointer access when plugin editor window closes

### 3. Dark Theme Color Cleanup
- Added 8 new ColorScheme fields: `selectionFill`, `connectorLine`, `incrementBg`, `incrementBorder`, `incrementFg`, `muteActive`, `vocoderRouting`, `bracketRouting`
- Defined values for both Classic and Dark themes
- Replaced all remaining hardcoded color literals in PatchCanvasComponent with scheme references

## Testing
- Both Standalone and VST3 builds compile successfully (MSVC, Release)
- VST3 recognized as instrument in Cubase
- Plugin window open/close no longer crashes
- Dark theme renders correctly with no hardcoded color remnants