### PR TITLE
Wire the front-panel Voices arrows to the synth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+- **Front-panel Voices arrows now reach the synth (issue #25)**: clicking the Voices
+  up/down arrows in the header bar updated the on-screen number but sent nothing to the
+  synth, so the voice count never actually changed — only Ctrl+P Patch Settings worked. The
+  header bar's `voiceChangeCallback` was defined but never wired up. It now re-uploads the
+  patch (the G1 stores the voice count in the patch header, so a re-upload is how the change
+  propagates), matching the Patch Settings path, for both the main window and slot windows.
+
 - **Windows build fixed (issue #24)**: the MCP-bridge "Copy" button's revert timer in the
   Editor Options dialog used a lambda init-capture initialised by a function-style cast
   (`SafePointer<...> (this)`), which MSVC refused to parse — Clang and GCC accepted it, so

--- a/source/MainComponent.cpp
+++ b/source/MainComponent.cpp
@@ -606,6 +606,20 @@ MainComponent::MainComponent(juce::ApplicationProperties &props)
         connectionManager.sendParameter(activeSlot, 2, 1, morphIndex, value);
       });
 
+  // Wire the front-panel Voices arrows to the synth. The G1 keeps the voice
+  // count in the patch header, so — exactly like the Ctrl+P Patch Settings
+  // dialog — the change only reaches the synth by re-uploading the patch.
+  // Without this the arrows updated the on-screen number but sent nothing
+  // (issue #25). PatchHeaderBar has already applied the new value to the
+  // header before invoking this callback.
+  mainLayout->getHeaderBar().setVoiceChangeCallback(
+      [this](int voices) {
+        if (!currentPatch()) return;
+        mainLayout->getStatusBar().showMessage("Voices: " + juce::String(voices), 2000);
+        if (connectionManager.isConnected())
+          connectionManager.uploadPatch(connectionManager.getCurrentSlot(), *currentPatch());
+      });
+
   // Wire patch name changes to send to synth
   mainLayout->getHeaderBar().setNameChangeCallback(
       [this](const juce::String& newName) {
@@ -2627,6 +2641,12 @@ void MainComponent::wireSlotWindowContent(SlotWindow& window, int slot) {
     slotUndoManagers[slot].beginNewTransaction("Rename Patch");
     slotUndoManagers[slot].perform(new RenamePatchAction(*ctx(), oldName, newName));
     mainLayout->getSlotBar().setSlotName(slot, newName);
+  });
+  headerBar.setVoiceChangeCallback([this, slot, patch](int voices) {
+    if (!patch()) return;
+    mainLayout->getStatusBar().showMessage("Voices: " + juce::String(voices), 2000);
+    if (connectionManager.isConnected())
+      connectionManager.uploadPatch(slot, *patch());
   });
   headerBar.setCableVisibilityCallback([&canvas]() { canvas.repaintCanvas(); });
   headerBar.setShakeCablesCallback([&canvas]() { canvas.shakeCables(); });


### PR DESCRIPTION
## Problem

Clicking the **Voices** up/down arrows in the front-panel header bar updated the on-screen number and repainted, but sent nothing to the synth — so the voice count never actually changed. Only **Ctrl+P → Patch Settings** worked. Reported in #25.

## Cause

`PatchHeaderBar` exposes a `voiceChangeCallback`, but `MainComponent` never wired it up — neither for the main window nor for slot windows. The Patch Settings dialog works because, after editing, it re-uploads the patch (`connectionManager.uploadPatch(...)`). The G1 stores the voice count in the patch header, so a re-upload is the mechanism by which the change reaches the synth.

## Fix

Wire `setVoiceChangeCallback` in both places, mirroring the Patch Settings path:

- **Main window** — upload `currentPatch()` to the current slot.
- **Slot windows** — upload `slotPatches[slot]` to that window's fixed slot (so the same bug isn't left latent there).

Both also show a `Voices: N` status message.

## Verification

Builds cleanly with MSVC (VS 2022). Confirmed working against real Nord Modular G1 hardware by the reporter — the synth now reassigns voices from the front-panel arrows.

Fixes #25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)